### PR TITLE
removing stack protection from C files in windows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -409,6 +409,13 @@ pub fn createSDL(b: *std.Build, target: std.zig.CrossTarget, optimize: std.built
                 "-DHAVE_LINUX_INPUT_H", //TODO: properly check for this like the CMake script does
             });
         },
+        .windows => {
+            // windows has no stack checking support
+            try c_flags.appendSlice(&.{ 
+                "-mno-stack-arg-probe", 
+                "-fno-stack-protector" 
+            });
+        },
         else => {},
     }
 


### PR DESCRIPTION
This allowed me to link to sdl2.lib statically within msvc!

but I still get the replaced error when example tries to link to it shared